### PR TITLE
Add Missing Timestamp Case to lsm6dso32_fifo_sensor_tag_get

### DIFF
--- a/lsm6dso32_reg.c
+++ b/lsm6dso32_reg.c
@@ -6163,6 +6163,10 @@ int32_t lsm6dso32_fifo_sensor_tag_get(stmdev_ctx_t *ctx,
       *val = LSM6DSO32_TEMPERATURE_TAG;
       break;
 
+    case LSM6DSO32_TIMESTAMP_TAG:
+      *val = LSM6DSO32_TIMESTAMP_TAG;
+      break;
+
     case LSM6DSO32_CFG_CHANGE_TAG:
       *val = LSM6DSO32_CFG_CHANGE_TAG;
       break;


### PR DESCRIPTION
First off, thanks for making this easily accessible :)

I noticed that the lsm6dso32_fifo_sensor_tag_get function, is missing the case for the timestamp tag.
So the function was incorrectly returning the default value (gyro tag).